### PR TITLE
Remove unnecessary Exclude settings in  .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,9 +8,6 @@ AllCops:
 Naming/FileName:
   Exclude:
     - lib/rubocop-on-rbs.rb
-    - CHANGELOG.md
-    - CODE_OF_CONDUCT.md
-    - README.md
 
 Lint/AssignmentInCondition:
   Enabled: false


### PR DESCRIPTION
Markdown files are not the target of RuboCop, so there is no need to set an exclusion. https://github.com/rubocop/rubocop/blob/31be3004ffb6c6bb8a5dc105993622c2c5aa99f4/config/default.yml#L11-L64