### PR TITLE
Add a setting to exclude rbs files from `Style/FrozenStringLiteralComment`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -15,6 +15,10 @@ Style:
   Exclude:
     - '**/*.rbs'
 
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - '**/*.rbs'
+
 # RBS
 
 RBS:


### PR DESCRIPTION
When using with `RuboCop-1.71`, rbs files started receiving warnings for `Style/FrozenStringLiteralComment`.

```shell
$ bundle exec rubocop sig/app/models/transfer_receipt.rbs
Inspecting 1 file
C

Offenses:

sig/app/models/transfer_receipt.rbs:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
# Generated from app/models/transfer_receipt.rb with RBS::Inline
^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

An exclude setting has been added to `Style/FrozenStringLiteralComment` in the main RuboCop. To maintain the same results as before, we will also add the exclude setting to `Style/FrozenStringLiteralComment` here.

ref: https://github.com/rubocop/rubocop/pull/13699/commits/e4bf6a5ea60e7cc3405fe7ef12b458b8fc7dbe47