### PR TITLE
Support documentation URL for department

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,8 @@ RBS:
 
 RBS/Layout:
   Enabled: true
+  DocumentationBaseURL: 'https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages'
+  DocumentationExtension: '.adoc'
 
 RBS/Layout/CommentIndentation:
   Description: 'Use 2 spaces for comment indentation'
@@ -104,6 +106,8 @@ RBS/Layout/TrailingWhitespace:
 RBS/Lint:
   Severity: warning
   Enabled: true
+  DocumentationBaseURL: 'https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages'
+  DocumentationExtension: '.adoc'
 
 RBS/Lint/AmbiguousKeywordArgumentKey:
   Description: 'Check ambiguous keyword argument key'
@@ -165,6 +169,8 @@ RBS/Lint/WillSyntaxError:
 
 RBS/Style:
   Enabled: true
+  DocumentationBaseURL: 'https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages'
+  DocumentationExtension: '.adoc'
 
 RBS/Style/BlockReturnBoolish:
   Description: 'Use `bool` for block return type'


### PR DESCRIPTION
We will be able to jump to the document page from a hover link.

<img width="608" alt="image" src="https://github.com/user-attachments/assets/be03e68a-dc12-4f69-9f29-137075ebdcaa" />
