### PR TITLE
[RBS/Lint/DuplicateOverload] Ignore the difference of return type.

### DIFF
--- a/docs/modules/ROOT/pages/cops_rbs_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_rbs_lint.adoc
@@ -76,19 +76,17 @@ def foo: (A | (B & C)) -> void
 | -
 |===
 
-Checks that there are no repeated overload bodies
+Checks that there are no repeated overload bodies.
+This cop ignores the difference of return type.
 
 [#examples-rbslintduplicateoverload]
 === Examples
-
-[#default-rbslintduplicateoverload]
-==== default
 
 [source,rbs]
 ----
 # bad
 def foo: () -> void
-       | () -> void
+       | () -> top
 ----
 
 [#rbslintimplicitlyreturnsnil]

--- a/lib/rubocop/cop/rbs/lint/duplicate_overload.rb
+++ b/lib/rubocop/cop/rbs/lint/duplicate_overload.rb
@@ -4,12 +4,13 @@ module RuboCop
   module Cop
     module RBS
       module Lint
-        # Checks that there are no repeated overload bodies
+        # Checks that there are no repeated overload bodies.
+        # This cop ignores the difference of return type.
         #
-        # @example default
+        # @example
         #   # bad
         #   def foo: () -> void
-        #          | () -> void
+        #          | () -> top
         #
         class DuplicateOverload < RuboCop::RBS::CopBase
           MSG = 'Duplicate overload body detected.'
@@ -21,12 +22,21 @@ module RuboCop
 
               next_overloads = overloads[(idx + 1)..-1]
               next_overloads.each do |next_overload|
-                next unless overload.method_type == next_overload.method_type
+                a = method_type_with_untyped_return_type(overload.method_type)
+                b = method_type_with_untyped_return_type(next_overload.method_type)
+                next unless a == b
 
                 range = location_to_range(next_overload.method_type.location)
                 add_offense(range)
               end
             end
+          end
+
+          private
+
+          def method_type_with_untyped_return_type(method_type)
+            type = method_type.type.with_return_type(::RBS::Types::Bases::Any.new(location: nil))
+            method_type.update(type:)
           end
         end
       end

--- a/spec/rubocop/cop/rbs/lint/duplicate_overload_spec.rb
+++ b/spec/rubocop/cop/rbs/lint/duplicate_overload_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe RuboCop::Cop::RBS::Lint::DuplicateOverload, :config do
     expect_offense(<<~RBS)
       class Foo
         def foo: () -> void
+               | (top) -> top
                | () -> top
-               | () -> void
-                 ^^^^^^^^^^ Duplicate overload body detected.
+                 ^^^^^^^^^ Duplicate overload body detected.
         def bar: () -> top
                | () { () -> top } -> top
-               | () { () -> top } -> top
-                 ^^^^^^^^^^^^^^^^^^^^^^^ Duplicate overload body detected.
+               | () { () -> top } -> void
+                 ^^^^^^^^^^^^^^^^^^^^^^^^ Duplicate overload body detected.
       end
     RBS
   end


### PR DESCRIPTION
Such overloading makes no sense. It should be detectable by this Cop.

```rbs
class Range
  def size: () -> Integer?
          | () -> Float?
end
```