### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [2.0.0] - 2026-03-27
+
+* Support rbs v4 by @ksss in https://github.com/ksss/rubocop-on-rbs/pull/145
+* Drop `RBS/Lint/WillSyntaxError` by @ksss in https://github.com/ksss/rubocop-on-rbs/pull/145
+
 ## [1.9.1] - 2026-02-10
 
 * [RBS/Layout/OverloadIndentation] Fix false positive by @ksss in https://github.com/ksss/rubocop-on-rbs/pull/141

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-on-rbs (1.9.1)
+    rubocop-on-rbs (2.0.0)
       lint_roller (~> 1.1)
       rbs (~> 4.0)
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs/version.rb
+++ b/lib/rubocop/rbs/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RBS
-    VERSION = '1.9.1'
+    VERSION = '2.0.0'
   end
 end


### PR DESCRIPTION
## Summary

- Bump version to 2.0.0
- Update CHANGELOG for 2.0.0 release

This release marks full commitment to rbs v4 support:
- Support rbs v4 (`~> 4.0`)
- Drop `RBS/Lint/WillSyntaxError` (no longer needed as rbs v4 makes the condition a syntax error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)